### PR TITLE
Add translucent background image to coming soon section

### DIFF
--- a/index.css
+++ b/index.css
@@ -970,6 +970,23 @@ nav ul li a:hover {
     border-radius: var(--border-radius-lg); /* Büyük yuvarlak köşeler */
     margin-top: 6rem; /* Üst boşluk */
     overflow: hidden; /* Taşmayı gizle */
+    position: relative; /* Arka plan katmanı için */
+}
+
+/* Yarı saydam arka plan görseli */
+.newsletter-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('x1.png') center/cover no-repeat;
+    opacity: 0.3; /* Yarı saydamlık */
+    pointer-events: none; /* Etkileşimi engelleme */
+}
+
+/* İçerik üstte kalsın */
+.newsletter-section > * {
+    position: relative;
+    z-index: 1;
 }
 
 /* Haber bülteni bölüm başlığı */


### PR DESCRIPTION
## Summary
- Overlay `x1.png` as a semi-transparent background for the newsletter section so the blue color remains visible.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/projex/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68950478e9f4832691080478e90fd4ea