### PR TITLE
fix: center navigation and prevent full screen width

### DIFF
--- a/index.css
+++ b/index.css
@@ -70,11 +70,11 @@ html, body {
 /* Başlık bölümü */
 header {
     max-width: 1040px; /* Navigasyon konteynerini daralt */
-    margin: 0 auto; /* Ortala */
     position: fixed; /* Sayfa kayarken sabit kalır */
     top: 1.5rem; /* Üstten biraz aşağı it */
-    left: 0;
-    right: 0;
+    left: 50%; /* Ortala */
+    transform: translateX(-50%); /* Ortalamayı düzelt */
+    width: calc(100% - 2rem); /* Ekranı kaplamasını engelle */
     z-index: 100; /* Katman sırasını ayarla */
     padding: 0 1rem; /* Yan boşluklar ekle */
 }
@@ -2025,6 +2025,9 @@ nav.mobile-menu-open .mobile-menu-toggle .icon-menu { display: none; }
     header {
         max-width: none;
         top: 0;
+        left: 0;
+        transform: none;
+        width: 100%;
         padding: 0;
         border-radius: 0;
         background-color: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
## Summary
- Center navigation header and limit its width to avoid covering the screen
- Ensure mobile header spans full width without offset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953084f9548326b6011a1d2efe8d99