### PR TITLE
Fix initial whitespace above hero slides

### DIFF
--- a/index.css
+++ b/index.css
@@ -71,7 +71,7 @@ html, body {
 header {
     max-width: 1040px; /* Navigasyon konteynerini daralt */
     position: fixed; /* Sayfa kayarken sabit kalır */
-    top: 1rem; /* Üstteki boşluğu azalttık */
+    top: 0; /* Sayfanın en üstüne hizala */
     left: 50%; /* Ortala */
     transform: translateX(-50%); /* Ortalamayı düzelt */
     width: calc(100% - 2rem); /* Ekranı kaplamasını engelle */
@@ -339,7 +339,7 @@ nav ul li a:hover {
 }
 
 #section-1 {
-    padding-top: var(--header-spacing-desktop);
+    padding-top: 0; /* İlk yüklemede slaytların üstündeki boşluğu kaldır */
 }
 
 #section-2 {


### PR DESCRIPTION
## Summary
- Align header to the top of the page and remove extra padding from the first section so hero slides start immediately below the header

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68960a44107c8326800775df191be0a8