### PR TITLE
Add manual hero slide arrows

### DIFF
--- a/index.css
+++ b/index.css
@@ -542,6 +542,29 @@ nav ul li a:hover {
     z-index: 2;
 }
 
+/* Hero progress navigation arrows */
+.hero-progress-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: rgba(0, 0, 0, 0.5);
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero-progress-arrow.hero-prev {
+    left: -1.5rem;
+}
+
+.hero-progress-arrow.hero-next {
+    right: -1.5rem;
+}
+
 /* Ayırıcı çubukları */
 .divider span {
     width: 80px;

--- a/index.html
+++ b/index.html
@@ -150,9 +150,15 @@
                                 <p id="heroDescription">Velileri, servis firmalarını ve okulları tek çatı altında buluşturan yeni nesil platform: Anlık rota takibi ve akıllı zamanlama ile daha güvenli ve verimli yolculuklar.</p>
                             </div>
                             <div class="divider" id="heroProgress">
+                                <button class="hero-progress-arrow hero-prev" id="heroPrev" aria-label="Önceki slayt">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="11 17 6 12 11 7"></polyline></svg>
+                                </button>
                                 <span></span>
                                 <span></span>
                                 <span></span>
+                                <button class="hero-progress-arrow hero-next" id="heroNext" aria-label="Sonraki slayt">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 7 18 12 13 17"></polyline></svg>
+                                </button>
                             </div>
                         </div>
                         <div class="hero-visual-container">

--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ const heroTextWrapperEl = document.getElementById('heroTextWrapper');
 const heroTitleEl = document.getElementById('heroTitle');
 const heroDescriptionEl = document.getElementById('heroDescription');
 const heroProgressSpans = document.querySelectorAll('#heroProgress span');
+const heroPrevBtn = document.getElementById('heroPrev');
+const heroNextBtn = document.getElementById('heroNext');
+let heroSlideInterval;
 function showHeroSlide(index) {
     if (!heroTextWrapperEl || !heroTitleEl || !heroDescriptionEl || !heroProgressSpans.length || !heroEl) return;
     // Remove previous slide classes and add the current one for background changes
@@ -44,6 +47,29 @@ function showHeroSlide(index) {
 function nextHeroSlide() {
     currentHeroSlideIndex = (currentHeroSlideIndex + 1) % heroSlides.length;
     showHeroSlide(currentHeroSlideIndex);
+}
+function prevHeroSlide() {
+    currentHeroSlideIndex = (currentHeroSlideIndex - 1 + heroSlides.length) % heroSlides.length;
+    showHeroSlide(currentHeroSlideIndex);
+}
+function startHeroSlideInterval() {
+    heroSlideInterval = setInterval(nextHeroSlide, slideDuration);
+}
+function resetHeroSlideInterval() {
+    clearInterval(heroSlideInterval);
+    startHeroSlideInterval();
+}
+if (heroPrevBtn) {
+    heroPrevBtn.addEventListener('click', () => {
+        prevHeroSlide();
+        resetHeroSlideInterval();
+    });
+}
+if (heroNextBtn) {
+    heroNextBtn.addEventListener('click', () => {
+        nextHeroSlide();
+        resetHeroSlideInterval();
+    });
 }
 // --- Interactive Journey Logic ---
 const journeyData = [
@@ -358,7 +384,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Hero slider setup
     if (heroTextWrapperEl && heroProgressSpans.length > 0) {
         showHeroSlide(currentHeroSlideIndex);
-        setInterval(nextHeroSlide, slideDuration);
+        startHeroSlideInterval();
     }
     // Mobile Navigation Accordion (for inside slide-out menu)
     document.querySelectorAll('.dropdown > a').forEach(toggle => {


### PR DESCRIPTION
## Summary
- Add previous and next arrow buttons beside hero progress bars for manual slide control
- Style arrows to be small and semi-transparent, aligned around the progress lines
- Implement JavaScript handlers that navigate slides and restart the autoplay interval

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962dcaa06c83269bf6ae82159a7ad3